### PR TITLE
Updates validateUtmZone() northing RangeError

### DIFF
--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -31,7 +31,7 @@ void validateUtmZone({
     throw RangeError.value(easting);
   }
   if (northing < 0) {
-    throw RangeError.value(easting);
+    throw RangeError.value(northing);
   }
   if (zoneNumber < _minZone || _maxZone < zoneNumber) {
     throw RangeError.range(zoneNumber, _minZone, _maxZone);


### PR DESCRIPTION
Using a negative value for Northing in the UTM coordinate now throws the RangeError with the nothing value