### PR TITLE
Adds functionality to give multiple latitude and longitude points as input and calculate 

### DIFF
--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -9,6 +9,13 @@ class _GeoSysParam {
   _GeoSysParam(this.r, this.e);
 }
 
+class _EastingAndNorthing {
+  final double easting;
+  final double northing;
+
+  _EastingAndNorthing(this.easting, this.northing);
+}
+
 final Map<GeodeticSystemType, _GeoSysParam> _geoSysMap = {
   GeodeticSystemType.wgs84: _GeoSysParam(6378137, 0.00669438),
   GeodeticSystemType.grs80: _GeoSysParam(6378137, 0.00669438),
@@ -139,11 +146,11 @@ class UtmConverter {
     final zoneLetter = _lat2zoneLetter(lat);
     final zoneNumber = _latlon2zoneNumber(lat, lon);
 
-    final eastingNorthing =
+    final eastingAndNorthing =
         _calculateEastingNorthing(lat, lon, zoneNumber, zoneLetter);
 
-    return UtmCoordinate(lat, lon, eastingNorthing[0], eastingNorthing[1],
-        zoneNumber, _lat2zoneLetter(lat));
+    return UtmCoordinate(lat, lon, eastingAndNorthing.easting,
+        eastingAndNorthing.northing, zoneNumber, _lat2zoneLetter(lat));
   }
 
   /// convert to list of UTM from list of lat&lon
@@ -153,16 +160,22 @@ class UtmConverter {
     final zoneLetter = _lat2zoneLetter(lat[0]);
 
     for (var i = 0; i < lat.length; i++) {
-      final eastingNorthing =
+      final eastingAndNorthing =
           _calculateEastingNorthing(lat[i], lon[i], zoneNumber, zoneLetter);
 
-      utmCoordinates.add(UtmCoordinate(lat[i], lon[i], eastingNorthing[0],
-          eastingNorthing[1], zoneNumber, zoneLetter));
+      utmCoordinates.add(UtmCoordinate(
+          lat[i],
+          lon[i],
+          eastingAndNorthing.easting,
+          eastingAndNorthing.northing,
+          zoneNumber,
+          zoneLetter));
     }
     return utmCoordinates;
   }
 
-  List<double> _calculateEastingNorthing(lat, lon, zoneNumber, zoneLetter) {
+  _EastingAndNorthing _calculateEastingNorthing(
+      lat, lon, zoneNumber, zoneLetter) {
     final latRad = Angle.degrees(lat).radians;
     final latSin = math.sin(latRad);
     final latCos = math.cos(latRad);
@@ -207,7 +220,7 @@ class UtmConverter {
                                 600 * c -
                                 330 * _eP2))) +
         offset;
-    return [easting, northing];
+    return _EastingAndNorthing(easting, northing);
   }
 
   String _lat2zoneLetter(double lat) {

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -136,13 +136,39 @@ class UtmConverter {
 
   /// convert to UTM from lat&lon
   UtmCoordinate latlonToUtm(double lat, double lon) {
+    final zoneLetter = _lat2zoneLetter(lat);
+    final zoneNumber = _latlon2zoneNumber(lat, lon);
+
+    final eastingNorthing =
+        _calculateEastingNorthing(lat, lon, zoneNumber, zoneLetter);
+
+    return UtmCoordinate(lat, lon, eastingNorthing[0], eastingNorthing[1],
+        zoneNumber, _lat2zoneLetter(lat));
+  }
+
+  /// convert to list of UTM from list of lat&lon
+  List<UtmCoordinate> multipleLatlonToUtm(List<double> lat, List<double> lon) {
+    var utmCoordinates = <UtmCoordinate>[];
+    final zoneNumber = _latlon2zoneNumber(lat[0], lon[0]);
+    final zoneLetter = _lat2zoneLetter(lat[0]);
+
+    for (var i = 0; i < lat.length; i++) {
+      final eastingNorthing =
+          _calculateEastingNorthing(lat[i], lon[i], zoneNumber, zoneLetter);
+
+      utmCoordinates.add(UtmCoordinate(lat[i], lon[i], eastingNorthing[0],
+          eastingNorthing[1], zoneNumber, zoneLetter));
+    }
+    return utmCoordinates;
+  }
+
+  List<double> _calculateEastingNorthing(lat, lon, zoneNumber, zoneLetter) {
     final latRad = Angle.degrees(lat).radians;
     final latSin = math.sin(latRad);
     final latCos = math.cos(latRad);
     final latTan = latSin / latCos;
     final latTan2 = latTan * latTan;
     final latTan4 = latTan2 * latTan2;
-    final zoneNumber = _latlon2zoneNumber(lat, lon);
     final lonRad = Angle.degrees(lon).radians;
     final centralLon = _zoneNumber2CentralLon(zoneNumber);
     final centralLonRad = Angle.degrees(centralLon).radians;
@@ -181,68 +207,7 @@ class UtmConverter {
                                 600 * c -
                                 330 * _eP2))) +
         offset;
-    return UtmCoordinate(
-        lat, lon, easting, northing, zoneNumber, _lat2zoneLetter(lat));
-  }
-
-  /// convert to list of UTM from list of lat&lon
-  List<UtmCoordinate> multipleLatlonToUtm(List<double> lat, List<double> lon) {
-    var utmCoordinates = <UtmCoordinate>[];
-    final zoneNumber = _latlon2zoneNumber(lat[0], lon[0]);
-    final zoneLetter = _lat2zoneLetter(lat[0]);
-
-    for (var i = 0; i < lat.length; i++) {
-      final latRad = Angle.degrees(lat[i]).radians;
-      final latSin = math.sin(latRad);
-      final latCos = math.cos(latRad);
-      final latTan = latSin / latCos;
-      final latTan2 = latTan * latTan;
-      final latTan4 = latTan2 * latTan2;
-      final lonRad = Angle.degrees(lon[i]).radians;
-      final centralLon = _zoneNumber2CentralLon(zoneNumber);
-      final centralLonRad = Angle.degrees(centralLon).radians;
-
-      final n = _r / math.sqrt(1 - _e * math.pow(latSin, 2));
-      final c = _eP2 * math.pow(latCos, 2);
-      final a = latCos * (lonRad - centralLonRad);
-      final a2 = a * a;
-      final a3 = a2 * a;
-      final a4 = a3 * a;
-      final a5 = a4 * a;
-      final a6 = a5 * a;
-      final m = _r *
-          (_m1 * latRad -
-              _m2 * math.sin(2 * latRad) +
-              _m3 * math.sin(4 * latRad) -
-              _m4 * math.sin(6 * latRad));
-      final easting = _k0 *
-              n *
-              (a +
-                  a3 / 6 * (1 - latTan2 + c) +
-                  a5 /
-                      120 *
-                      (5 - 18 * latTan2 + latTan4 + 72 * c - 58 * _eP2)) +
-          500000;
-      final offset = lat[i] >= 0 ? 0 : 10000000;
-      final northing = _k0 *
-              (m +
-                  n *
-                      latTan *
-                      (a2 / 2 +
-                          a4 / 24 * (5 - latTan2 + 9 * c + 4 * math.pow(c, 2)) +
-                          a6 /
-                              720 *
-                              (61 -
-                                  58 * latTan2 +
-                                  latTan4 +
-                                  600 * c -
-                                  330 * _eP2))) +
-          offset;
-
-      utmCoordinates.add(UtmCoordinate(
-          lat[i], lon[i], easting, northing, zoneNumber, zoneLetter));
-    }
-    return utmCoordinates;
+    return [easting, northing];
   }
 
   String _lat2zoneLetter(double lat) {

--- a/lib/src/utm_base.dart
+++ b/lib/src/utm_base.dart
@@ -43,4 +43,27 @@ class UTM {
     validateRangeOfLatLon(lat: lat, lon: lon);
     return UtmConverter(type).latlonToUtm(lat, lon);
   }
+
+  /// create List<[UtmCoordinate]> from multiple latitudes & longitudes
+  /// The UTM zone number and letter are scalars and will be calculated for
+  /// the first index of the given List<[lat]> and List<[lon]>
+  /// All other points will be set into the same UTM zone.
+  /// Therefore it's a good idea to make sure all points are near each other
+  /// in order to avoid distortion.
+  /// List<[lat]> latitudes between -80 and 84 deg
+  /// List<[lon]> longitudes between -180 and 180 deg
+  /// [type] type of Geodetic System. Default is WGS84. see [GeodeticSystemType]
+  static List<UtmCoordinate> fromMultipleLatLon({
+    required List<double> lat,
+    required List<double> lon,
+    GeodeticSystemType type = GeodeticSystemType.wgs84,
+  }) {
+    validateLengthListOfLatLon(lat: lat, lon: lon);
+
+    for (var i = 0; i < lat.length; i++) {
+      validateRangeOfLatLon(lat: lat[i], lon: lon[i]);
+    }
+
+    return UtmConverter(type).multipleLatlonToUtm(lat, lon);
+  }
 }

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -40,3 +40,14 @@ void validateUtmZone({
     throw ArgumentError.value(zoneLetter);
   }
 }
+
+/// validate length of list of lat and lon
+void validateLengthListOfLatLon({
+  required List<double> lat,
+  required List<double> lon,
+}) {
+  if (lat.length != lon.length) {
+    throw ArgumentError(
+        'The length of the lat and lon arguments must be match');
+  }
+}

--- a/test/utm_test.dart
+++ b/test/utm_test.dart
@@ -58,5 +58,9 @@ void main() {
     expect(utms[0].zoneNumber, equals(32));
     expect(utms[1].zoneLetter, equals('V'));
     expect(utms[1].zoneNumber, equals(32));
+    expect(utms[0].easting, closeTo(561286.37220385, 0.1));
+    expect(utms[0].northing, closeTo(6368259.47923512, 0.1));
+    expect(utms[1].easting, closeTo(799879.76122786, 0.1));
+    expect(utms[1].northing, closeTo(6378839.86148105, 0.1));
   });
 }

--- a/test/utm_test.dart
+++ b/test/utm_test.dart
@@ -50,4 +50,13 @@ void main() {
     expect(utm.zoneLetter, equals('X'));
     expect(utm.zoneNumber, equals(37));
   });
+
+  test('multiple latlon to utm Test in zone 32', () {
+    final utms = UTM.fromMultipleLatLon(
+        lat: [57.452869, 57.452869], lon: [10.021325, 14.000000]);
+    expect(utms[0].zoneLetter, equals('V'));
+    expect(utms[0].zoneNumber, equals(32));
+    expect(utms[1].zoneLetter, equals('V'));
+    expect(utms[1].zoneNumber, equals(32));
+  });
 }

--- a/test/validate_test.dart
+++ b/test/validate_test.dart
@@ -45,4 +45,10 @@ void main() {
             easting: 1, northing: 1, zoneNumber: 1, zoneLetter: 'Z'),
         throwsArgumentError);
   });
+  test('invalid argument length', () {
+    expect(
+        () => UTM.fromMultipleLatLon(
+            lat: [57.452869, 57.452869], lon: [10.021325, 14.000000, 0.0]),
+        throwsArgumentError);
+  });
 }


### PR DESCRIPTION
This library is a translation of the [Python utm library](https://github.com/Turbo87/utm) which has the ability to give multiple latitude and longitude points as input to calculate UTM points in the UTM zone of the first point in the input. 

This pull request adds the fromMultipleLatlon method which calculates the UTM coordinates from lists of latitudes and longitudes in the UTM zone of the first inputted latLon. 